### PR TITLE
Raise an error if string is invalid after unescaping

### DIFF
--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -132,9 +132,14 @@ module PostRank
     def unescape(uri)
       u = parse(uri)
       u.query = u.query.tr('+', ' ') if u.query
-      u.to_s.gsub(URIREGEX[:unescape]) do
+      str = u.to_s.gsub(URIREGEX[:unescape]) do
         [$1.delete('%')].pack('H*')
       end
+      str.force_encoding("UTF-8")
+      unless str.valid_encoding?
+        raise Addressable::URI::InvalidURIError, "URI contains invalid characters: '#{u}'"
+      end
+      str
     end
 
     def clean(uri, opts = {})

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -45,6 +45,11 @@ describe PostRank::URI do
       end
     end
 
+    it "should raise an error on invalid characters" do
+      expect do
+        PostRank::URI.unescape("http://www.example.com/foo%bar%acbaz")
+      end.to raise_error(Addressable::URI::InvalidURIError)
+    end
   end
 
   context "normalize" do
@@ -206,6 +211,12 @@ describe PostRank::URI do
     it "should remove trailing slashes, unless asked not to" do
       c('http://igvita.com/foo/').should == 'http://igvita.com/foo'
       c('http://igvita.com/foo/', :remove_trailing_slash => false).should == 'http://igvita.com/foo/'
+    end
+
+    it "should raise an error on invalid characters" do
+      expect do
+        PostRank::URI.clean("http://www.example.com/foo%bar%acbaz")
+      end.to raise_error(Addressable::URI::InvalidURIError)
     end
 
     it "should clean host specific parameters" do


### PR DESCRIPTION
Pointing this at a Ruby 1.9.x branch. I'll merge forward to master after merging there.

This seems safe since Addressable::URI#to_s already returns a UTF-8 encoded string. This just ensures that if after unescaping the string is no longer UTF-8 we throw a reasonable exception.
