### PR TITLE
Only unescape unreserved characters in clean

### DIFF
--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -89,7 +89,7 @@ module PostRank
 
     URIREGEX[:escape]   = /([^ a-zA-Z0-9_.-]+)/x
     URIREGEX[:unescape] = /((?:%[0-9a-fA-F]{2})+)/x
-    URIREGEX[:reserved] = /(%(?:21|23|24|26|27|28|29|2A|2B|2C|2F|3A|3B|3D|3F|40|5B|5D))/x
+    URIREGEX[:reserved] = /(%(?:21|23|24|25|26|27|28|29|2A|2B|2C|2F|3A|3B|3D|3F|40|5B|5D))/x
     URIREGEX.each_pair{|k,v| v.freeze }
 
     module_function

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -52,6 +52,20 @@ describe PostRank::URI do
     end
   end
 
+  context "unescape_unreserved" do
+    def uu(uri)
+      PostRank::URI.unescape_unreserved(uri).to_s
+    end
+
+    it "should not unescape reserved characters" do
+      uu("example.com/what%3F").should == "http://example.com/what%3F"
+    end
+
+    it "should escape unreserved characters" do
+      uu("example.com/some%20thing").should == "http://example.com/some thing"
+    end
+  end
+
   context "normalize" do
     def n(uri, opts = {})
       PostRank::URI.normalize(uri, opts).to_s
@@ -206,6 +220,9 @@ describe PostRank::URI do
       c('igvita.com?id="').should == 'http://igvita.com/?id=%22'
 
       c('test.tumblr.com/post/23223/text-stub').should == 'http://test.tumblr.com/post/23223'
+
+      c('example.com/do_you_%23yolo%3F').should == 'http://example.com/do_you_%23yolo%3F'
+      c('example.com/search?q=%23fomo&limit=50#entry-1').should == 'http://example.com/search?q=%23fomo&limit=50'
     end
 
     it "should remove trailing slashes, unless asked not to" do

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -61,8 +61,12 @@ describe PostRank::URI do
       uu("example.com/what%3F").should == "http://example.com/what%3F"
     end
 
-    it "should escape unreserved characters" do
+    it "should unescape unreserved characters" do
       uu("example.com/some%20thing").should == "http://example.com/some thing"
+    end
+
+    it "should not unescape percents" do
+      uu("example.com/work%20110%25").should == "http://example.com/work 110%25"
     end
   end
 


### PR DESCRIPTION
From [RFC 3986](https://tools.ietf.org/html/rfc3986#section-2.4):

> [URIs] must be parsed and separated before the percent-encoded octets within
> those components can be safely decoded, as otherwise the data may be
> mistaken for component delimiters.  The only exception is for
> percent-encoded octets corresponding to characters in the unreserved
> set, which can be decoded at any time.
