### PR TITLE
Update nokogiri dependency to 1.7.1

### DIFF
--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "addressable",   "~> 2.3.0"
   s.add_dependency "public_suffix", "~> 1.5.3"
-  s.add_dependency "nokogiri",      "~> 1.6.1"
+  s.add_dependency "nokogiri",      "~> 1.7.1"
 
   s.add_development_dependency "rspec", "~> 2.99.0"
 


### PR DESCRIPTION
Update nokogiri dependency to 1.7.1 because of CVE-2016-4658 and CVE-2016-5131 in bundled libxml2.