### PR TITLE
Fix embedded uri issue

### DIFF
--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -210,9 +210,9 @@ module PostRank
 
     def embedded(uri)
       embedded = if uri.host == 'news.google.com' && uri.path == '/news/url' \
-         || uri.host == 'xfruits.com'
-        uri.query_values['url']
-
+          || uri.host == 'xfruits.com'
+        query_values = uri.query_values
+        query_values && query_values['url']
       elsif uri.host =~ /myspace\.com/ && uri.path =~ /PostTo/
         embedded = uri.query_values['u']
       end

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -239,6 +239,10 @@ describe PostRank::URI do
         u = c('http://www.myspace.com/Modules/PostTo/Pages/?u=http%3A%2F%2Fghanaian-chronicle.com%2Fnews%2Fother-news%2Fcanadian-high-commissioner-urges-media%2F&t=Canadian%20High%20Commissioner%20urges%20media')
         u.should == 'http://ghanaian-chronicle.com/news/other-news/canadian-high-commissioner-urges-media'
       end
+
+      it "should not error on empty query values" do
+        expect { c('http://xfruits.com/trabucojon/') }.to_not raise_exception
+      end
     end
   end
 


### PR DESCRIPTION
```
/u/apps/crawler/releases/20170821205716/vendor/cache/postrank-uri-3c6b46d34a58/lib/postrank-uri.rb:214:in `embedded'
/u/apps/crawler/releases/20170821205716/vendor/cache/postrank-uri-3c6b46d34a58/lib/postrank-uri.rb:191:in `c14n'
/u/apps/crawler/releases/20170821205716/vendor/cache/postrank-uri-3c6b46d34a58/lib/postrank-uri.rb:169:in `clean'
/u/apps/crawler/releases/20170821205716/vendor/cache/swiftype_utils-bb33a2637949/lib/swiftype_utils/url_parser.rb:133:in `fast_absolute'
/u/apps/crawler/releases/20170821205716/vendor/cache/swiftype_utils-bb33a2637949/lib/swiftype_utils/html_extractor.rb:153:in `block in links'
/u/apps/crawler/shared/bundle/jruby/2.3.0/gems/nokogiri-1.7.2-java/lib/nokogiri/xml/node_set.rb:187:in `block in each'
org/jruby/RubyInteger.java:134:in `upto'
/u/apps/crawler/shared/bundle/jruby/2.3.0/gems/nokogiri-1.7.2-java/lib/nokogiri/xml/node_set.rb:186:in `each'
org/jruby/RubyEnumerable.java:830:in `map'
/u/apps/crawler/releases/20170821205716/vendor/cache/swiftype_utils-bb33a2637949/lib/swiftype_utils/html_extractor.rb:147:in `links'
/u/apps/crawler/releases/20170821205716/lib/services/extractor_service.rb:430:in `block in process_http_response'
/u/apps/crawler/shared/bundle/jruby/2.3.0/gems/statsd-instrument-2.0.4/lib/statsd/instrument.rb:139:in `block in measure'
/u/apps/crawler/shared/bundle/jruby/2.3.0/gems/statsd-instrument-2.0.4/lib/statsd/instrument.rb:14:in `duration'
/u/apps/crawler/shared/bundle/jruby/2.3.0/gems/statsd-instrument-2.0.4/lib/statsd/instrument.rb:139:in `measure'
(eval):2:in `measure'
(eval):2:in `statsd_measure'
```

Addressable::URI#query_values returns nil when the query is blank:
http://www.rubydoc.info/gems/addressable/Addressable/URI#query_values-instance_method