### PR TITLE
Pull upstream back in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg
 Gemfile.lock
+/gemfiles

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
 before_install:
   - gem install bundler
 install:
-  - bundle install
+  - bundle install --jobs=3 --retry=3
 script:
   - bundle exec rake
   - bundle exec appraisal install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.1
   - 2.2
@@ -8,7 +9,7 @@ before_install:
   - gem install bundler
 install:
   - bundle install --jobs=3 --retry=3
+  - bundle exec appraisal install
 script:
   - bundle exec rake
-  - bundle exec appraisal install
   - bundle exec rake appraisal

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3
-  - 2.4
+  - 2.4.0
 before_install:
   - gem install bundler
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+rvm:
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+before_install:
+  - gem install bundler
+install:
+  - bundle install
+script:
+  - bundle exec rake
+  - bundle exec appraisal install
+  - bundle exec rake appraisal

--- a/Appraisals
+++ b/Appraisals
@@ -1,0 +1,19 @@
+appraise "nokogiri-1.7" do
+  gem "nokogiri", "~> 1.7.0"
+end
+
+appraise "nokogiri-1.6" do
+  gem "nokogiri", "~> 1.6.1"
+end
+
+appraise "addressable-2.3" do
+  gem "addressable", "~> 2.3.0"
+end
+
+appraise "addressable-2.4" do
+  gem "addressable", "~> 2.4.0"
+end
+
+appraise "addressable-2.5" do
+  gem "addressable", "~> 2.5.0"
+end

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PostRank URI
 
+[![Gem Version](https://badge.fury.io/rb/postrank-uri.svg)](https://rubygems.org/gems/postrank-uri) [![Build Status](https://travis-ci.org/postrank-labs/postrank-uri.svg?branch=master)](https://travis-ci.org/postrank-labs/postrank-uri)
+
 A collection of convenience methods (Ruby 1.8 & Ruby 1.9) for dealing with extracting, (un)escaping, normalization, and canonicalization of URIs. At PostRank we process over 20M URI associated activities each day, and we need to make sure that we can reliably extract the URIs from a variety of text formats, deal with all the numerous and creative ways users like to escape and unescape their URIs, normalize the resulting URIs, and finally apply a set of custom canonicalization rules to make sure that we can cross-reference when the users are talking about the same URL.
 
 In a nutshell, we need to make sure that creative cases like the ones below all resolve to same URI:

--- a/README.md
+++ b/README.md
@@ -38,3 +38,28 @@ In a nutshell, we need to make sure that creative cases like the ones below all 
 As part of URI canonicalization the library will remove common tracking parameters from Google Analytics and several other providers. Beyond that, host-specific rules are also applied. For example, nytimes.com likes to add a 'partner' query parameter for tracking purposes, but which has no effect on the content - hence, it is removed from the URI. For full list, see the c14n.yml file.
 
 Detecting "duplicate URLs" is a hard problem to solve (expensive in all senses), instead we are compiling a manually assembled database. If you find cases which are missing, please do report them, or send us a pull request!
+
+## Development
+
+### Setup
+
+```
+bundle install
+```
+
+### Running tests
+
+```
+bundle exec rake
+```
+
+### Running dependency appraisals
+
+To verify `postrake-uri` works with different versions of its runtime dependencies you can run:
+
+```
+bundle exec appraisal install
+bundle exec rake appraisal
+```
+
+This will execute the test suite with different versions of the dependencies.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/postrank-uri.svg)](https://rubygems.org/gems/postrank-uri) [![Build Status](https://travis-ci.org/postrank-labs/postrank-uri.svg?branch=master)](https://travis-ci.org/postrank-labs/postrank-uri)
 
-A collection of convenience methods (Ruby 1.8 & Ruby 1.9) for dealing with extracting, (un)escaping, normalization, and canonicalization of URIs. At PostRank we process over 20M URI associated activities each day, and we need to make sure that we can reliably extract the URIs from a variety of text formats, deal with all the numerous and creative ways users like to escape and unescape their URIs, normalize the resulting URIs, and finally apply a set of custom canonicalization rules to make sure that we can cross-reference when the users are talking about the same URL.
+A collection of convenience methods (Ruby 2.0+) for dealing with extracting, (un)escaping, normalization, and canonicalization of URIs. At PostRank we process over 20M URI associated activities each day, and we need to make sure that we can reliably extract the URIs from a variety of text formats, deal with all the numerous and creative ways users like to escape and unescape their URIs, normalize the resulting URIs, and finally apply a set of custom canonicalization rules to make sure that we can cross-reference when the users are talking about the same URL.
 
 In a nutshell, we need to make sure that creative cases like the ones below all resolve to same URI:
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,3 +3,6 @@ Bundler::GemHelper.install_tasks
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
+task :default => :spec
+
+require 'appraisal'

--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -86,7 +86,7 @@ module PostRank
           )
         }iox;
 
-    URIREGEX[:encoded_question_mark] = '%3F'
+    URIREGEX[:reserved_characters] = /%3F|%26/i
     URIREGEX[:escape]   = /([^ a-zA-Z0-9_.-]+)/x
     URIREGEX[:unescape] = /(%[0-9a-fA-F]{2})/x
     URIREGEX.each_pair{|k,v| v.freeze }
@@ -132,11 +132,11 @@ module PostRank
     def unescape(uri)
       u = parse(uri)
       u.query = u.query.tr('+', ' ') if u.query
-      u.to_s.gsub(URIREGEX[:unescape]) do |match|
-        if match == URIREGEX[:encoded_question_mark]
-          match
+      u.to_s.gsub(URIREGEX[:unescape]) do |encoded|
+        if encoded.match? URIREGEX[:reserved_characters]
+          encoded
         else
-          [match.delete('%')].pack('H*')
+          [encoded.delete('%')].pack('H*')
         end
       end
     end

--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -9,7 +9,7 @@ module Addressable
   class URI
     def domain
       host = self.host
-      (host && PublicSuffix.valid?(host)) ? PublicSuffix.parse(host).domain : nil
+      (host && PublicSuffix.valid?(host, default_rule: nil)) ? PublicSuffix.parse(host).domain : nil
     end
 
     def normalized_query
@@ -97,7 +97,7 @@ module PostRank
       urls = []
       text.to_s.scan(URIREGEX[:valid_url]) do |all, before, url, protocol, domain, path, query|
         # Only extract the URL if the domain is valid
-        if PublicSuffix.valid?(domain)
+        if PublicSuffix.valid?(domain, default_rule: nil)
           url = clean(url)
           urls.push url.to_s
         end
@@ -225,7 +225,7 @@ module PostRank
       cleaned_uri = clean(uri, :raw => true)
 
       if host = cleaned_uri.host
-        is_valid = PublicSuffix.valid?(Addressable::IDNA.to_unicode(host))
+        is_valid = PublicSuffix.valid?(Addressable::IDNA.to_unicode(host), default_rule: nil)
       end
 
       is_valid

--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -86,8 +86,9 @@ module PostRank
           )
         }iox;
 
+    URIREGEX[:encoded_question_mark] = '%3F'
     URIREGEX[:escape]   = /([^ a-zA-Z0-9_.-]+)/x
-    URIREGEX[:unescape] = /((?:%[0-9a-fA-F]{2})+)/x
+    URIREGEX[:unescape] = /(%[0-9a-fA-F]{2})/x
     URIREGEX.each_pair{|k,v| v.freeze }
 
     module_function
@@ -131,8 +132,12 @@ module PostRank
     def unescape(uri)
       u = parse(uri)
       u.query = u.query.tr('+', ' ') if u.query
-      u.to_s.gsub(URIREGEX[:unescape]) do
-        [$1.delete('%')].pack('H*')
+      u.to_s.gsub(URIREGEX[:unescape]) do |match|
+        if match == URIREGEX[:encoded_question_mark]
+          match
+        else
+          [match.delete('%')].pack('H*')
+        end
       end
     end
 

--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -133,7 +133,7 @@ module PostRank
       u = parse(uri)
       u.query = u.query.tr('+', ' ') if u.query
       u.to_s.gsub(URIREGEX[:unescape]) do |encoded|
-        if encoded.match? URIREGEX[:reserved_characters]
+        if !encoded.match(URIREGEX[:reserved_characters]).nil?
           encoded
         else
           [encoded.delete('%')].pack('H*')

--- a/lib/postrank-uri/version.rb
+++ b/lib/postrank-uri/version.rb
@@ -1,5 +1,5 @@
 module PostRank
   module URI
-    VERSION = "1.0.21"
+    VERSION = "1.0.22"
   end
 end

--- a/lib/postrank-uri/version.rb
+++ b/lib/postrank-uri/version.rb
@@ -1,5 +1,5 @@
 module PostRank
   module URI
-    VERSION = "1.0.19"
+    VERSION = "1.0.20"
   end
 end

--- a/lib/postrank-uri/version.rb
+++ b/lib/postrank-uri/version.rb
@@ -1,5 +1,5 @@
 module PostRank
   module URI
-    VERSION = "1.0.20"
+    VERSION = "1.0.21"
   end
 end

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = "URI normalization, c14n, escaping, and extraction"
   s.description = s.summary
   s.license     = 'MIT'
+  s.required_ruby_version  = ">= 2.0.0"
 
   s.rubyforge_project = "postrank-uri"
 

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "postrank-uri"
 
-  s.add_dependency "addressable",   "~> 2.3.0"
+  s.add_dependency "addressable",   ">= 2.3.0", "< 2.6"
   s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
   s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.8"
 

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "postrank-uri"
 
   s.add_dependency "addressable",   "~> 2.3.0"
-  s.add_dependency "public_suffix", "~> 1.4.2"
+  s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
   s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.8"
 
   s.add_development_dependency "rspec"

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "addressable",   "~> 2.3.0"
   s.add_dependency "public_suffix", "~> 1.4.2"
-  s.add_dependency "nokogiri",      "~> 1.6.1"
+  s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.8"
 
   s.add_development_dependency "rspec"
 

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "addressable",   ">= 2.3.0", "< 2.6"
   s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
-  s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.8"
+  s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.9"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -19,7 +19,9 @@ Gem::Specification.new do |s|
   s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
   s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.8"
 
+  s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
+  s.add_development_dependency "appraisal", ">= 2.0.0", "< 3.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -4,40 +4,40 @@ require 'helper'
 
 describe PostRank::URI do
   context "escaping" do
-    it "should escape PostRank::URI string" do
+    it "escapes PostRank::URI string" do
       expect(PostRank::URI.escape('id=1')).to eq('id%3D1')
     end
 
-    it "should escape spaces as %20's" do
+    it "escapes spaces as %20's" do
       expect(PostRank::URI.escape('id= 1')).to match('%20')
     end
   end
 
   context "unescape" do
-    it "should unescape PostRank::URI" do
+    it "unescapes PostRank::URI" do
       expect(PostRank::URI.unescape(PostRank::URI.escape('id=1'))).to eq('id=1')
     end
 
-    it "should unescape PostRank::URI with spaces" do
+    it "unescapes PostRank::URI with spaces" do
       expect(PostRank::URI.unescape(PostRank::URI.escape('id= 1'))).to eq('id= 1')
     end
 
     context "accept improperly escaped PostRank::URI strings" do
       # See http://tools.ietf.org/html/rfc3986#section-2.3
 
-      it "should unescape PostRank::URI with spaces encoded as '+'" do
+      it "unescapes PostRank::URI with spaces encoded as '+'" do
         expect(PostRank::URI.unescape('?id=+1')).to eq('?id= 1')
       end
 
-      it "should unescape PostRank::URI with spaces encoded as '+'" do
+      it "unescapes PostRank::URI with spaces encoded as '+'" do
         expect(PostRank::URI.unescape('?id%3D+1')).to eq('?id= 1')
       end
 
-      it "should unescape PostRank::URI with spaces encoded as %20" do
+      it "unescapes PostRank::URI with spaces encoded as %20" do
         expect(PostRank::URI.unescape('?id=%201')).to eq('?id= 1')
       end
 
-      it "should not unescape '+' to spaces in paths" do
+      it "does not unescape '+' to spaces in paths" do
         expect(PostRank::URI.unescape('/foo+bar?id=foo+bar')).to eq('/foo+bar?id=foo bar')
       end
     end
@@ -51,7 +51,7 @@ describe PostRank::URI do
       PostRank::URI.normalize(uri).to_s
     end
 
-    it "should normalize paths in PostRank::URIs" do
+    it "normalizes paths in PostRank::URIs" do
       expect(n('http://igvita.com/')).to eq(igvita)
       expect(n('http://igvita.com').to_s).to eq(igvita)
       expect(n('http://igvita.com///')).to eq(igvita)
@@ -61,35 +61,35 @@ describe PostRank::URI do
       expect(n('http://igvita.com/a/b/../..')).to eq(igvita)
     end
 
-    it "should normalize query strings in PostRank::URIs" do
+    it "normalizes query strings in PostRank::URIs" do
       expect(n('http://igvita.com/?')).to eq(igvita)
       expect(n('http://igvita.com?')).to eq(igvita)
       expect(n('http://igvita.com/a/../?')).to eq(igvita)
     end
 
-    it "should normalize anchors in PostRank::URIs" do
+    it "normalizes anchors in PostRank::URIs" do
       expect(n('http://igvita.com#test')).to eq(igvita)
       expect(n('http://igvita.com#test#test')).to eq(igvita)
       expect(n('http://igvita.com/a/../?#test')).to eq(igvita)
     end
 
-    it "should clean whitespace in PostRank::URIs" do
+    it "cleans whitespace in PostRank::URIs" do
       expect(n('http://igvita.com/a/../?  ')).to eq(igvita)
       expect(n('http://igvita.com/a/../? #test')).to eq(igvita)
       expect(n('http://igvita.com/ /../')).to eq(igvita)
     end
 
-    it "should default to http scheme if missing" do
+    it "defaults to http scheme if missing" do
       expect(n('igvita.com')).to eq(igvita)
       expect(n('https://test.com/').to_s).to eq('https://test.com/')
     end
 
-    it "should downcase hostname" do
+    it "downcases the hostname" do
       expect(n('IGVITA.COM')).to eq(igvita)
       expect(n('IGVITA.COM/ABC')).to eq(igvita + "ABC")
     end
 
-    it "should remove trailing slash on paths" do
+    it "removes trailing slash on paths" do
       expect(n('http://igvita.com/')).to eq('http://igvita.com/')
 
       expect(n('http://igvita.com/a')).to eq('http://igvita.com/a')
@@ -110,22 +110,22 @@ describe PostRank::URI do
         expect(c('igvita.com/?id=a&utm_source=a')).to eq('http://igvita.com/?id=a')
       end
 
-      it "should preserve order of parameters" do
+      it "preserves the order of parameters" do
         url = 'http://a.com/?'+('a'..'z').to_a.shuffle.map {|e| "#{e}=#{e}"}.join("&")
         expect(c(url)).to eq(url)
       end
 
-      it "should remove Google Analytics parameters" do
+      it "removes Google Analytics parameters" do
         expect(c('igvita.com/?id=a&utm_source=a')).to eq('http://igvita.com/?id=a')
         expect(c('igvita.com/?id=a&utm_source=a&utm_valid')).to eq('http://igvita.com/?id=a&utm_valid')
       end
 
-      it "should remove awesm/sms parameters" do
+      it "removes awesm/sms parameters" do
         expect(c('igvita.com/?id=a&utm_source=a&awesm=b')).to eq('http://igvita.com/?id=a')
         expect(c('igvita.com/?id=a&sms_ss=a')).to eq('http://igvita.com/?id=a')
       end
 
-      it "should remove PHPSESSID parameter" do
+      it "removes PHPSESSID parameter" do
         expect(c('http://www.nachi.org/forum?PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd')).to eq('http://www.nachi.org/forum?')
         expect(c('http://www.nachi.org/forum/?PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd')).to eq('http://www.nachi.org/forum/?')
         expect(c('http://www.nachi.org/forum?id=123&PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd')).to eq('http://www.nachi.org/forum?id=123')
@@ -133,7 +133,7 @@ describe PostRank::URI do
     end
 
     context "hashbang" do
-      it "should rewrite twitter links to crawlable versions" do
+      it "rewrites twitter links to crawlable versions" do
         expect(c('http://twitter.com/#!/igrigorik')).to eq('http://twitter.com/igrigorik')
         expect(c('http://twitter.com/#!/a/statuses/1')).to eq('http://twitter.com/a/statuses/1')
         expect(c('http://nontwitter.com/#!/a/statuses/1')).to eq('http://nontwitter.com/#!/a/statuses/1')
@@ -141,24 +141,24 @@ describe PostRank::URI do
     end
 
     context "tumblr" do
-      it "should strip slug" do
+      it "strips the slug" do
         expect(c('http://test.tumblr.com/post/4533459403/some-text')).to eq('http://test.tumblr.com/post/4533459403/')
         expect(c('http://tumblr.com/xjl2evo3hh')).to eq('http://tumblr.com/xjl2evo3hh')
       end
     end
 
     context "embedded links" do
-      it "should extract embedded redirects from Google News" do
+      it "extracts embedded redirects from Google News" do
         u = c('http://news.google.com/news/url?sa=t&fd=R&&url=http://www.ctv.ca/CTVNews/Politics/20110111/')
         expect(u).to eq('http://www.ctv.ca/CTVNews/Politics/20110111')
       end
 
-      it "should extract embedded redirects from xfruits.com" do
+      it "extracts embedded redirects from xfruits.com" do
         u = c('http://xfruits.com/MrGroar/?url=http%3A%2F%2Faap.lesroyaumes.com%2Fdepeches%2Fdepeche351820908.html')
         expect(u).to eq('http://aap.lesroyaumes.com/depeches/depeche351820908.html')
       end
 
-      it "should extract embedded redirects from MySpace" do
+      it "extracts embedded redirects from MySpace" do
         u = c('http://www.myspace.com/Modules/PostTo/Pages/?u=http%3A%2F%2Fghanaian-chronicle.com%2Fnews%2Fother-news%2Fcanadian-high-commissioner-urges-media%2F&t=Canadian%20High%20Commissioner%20urges%20media')
         expect(u).to eq('http://ghanaian-chronicle.com/news/other-news/canadian-high-commissioner-urges-media')
       end
@@ -170,7 +170,7 @@ describe PostRank::URI do
       PostRank::URI.clean(uri)
     end
 
-    it "should unescape, c14n and normalize" do
+    it "unescapes, canonicalizes and normalizes" do
       expect(c('http://igvita.com/?id=1')).to eq('http://igvita.com/?id=1')
       expect(c('igvita.com/?id=1')).to eq('http://igvita.com/?id=1')
 
@@ -186,7 +186,7 @@ describe PostRank::URI do
       expect(c('test.tumblr.com/post/23223/text-stub')).to eq('http://test.tumblr.com/post/23223')
     end
 
-    it "should clean host specific parameters" do
+    it "cleans host specific parameters" do
       YAML.load_file('spec/c14n_hosts.yml').each do |orig, clean|
         expect(c(orig)).to eq(clean)
       end
@@ -215,14 +215,14 @@ describe PostRank::URI do
       PostRank::URI.hash(uri, opts)
     end
 
-    it "should compute the MD5 hash without cleaning the URI" do
+    it "computes the MD5 hash without cleaning the URI" do
       hash = '55fae8910d312b7878a3201ed653b881'
 
       expect(h('http://everburning.com/feed/post/1')).to eq(hash)
       expect(h('everburning.com/feed/post/1')).not_to eq(hash)
     end
 
-    it "should normalize the URI if requested and compute MD5 hash" do
+    it "normalizes the URI if requested and compute MD5 hash" do
       hash = '55fae8910d312b7878a3201ed653b881'
 
       expect(h('http://EverBurning.Com/feed/post/1', :clean => true)).to eq(hash)
@@ -238,47 +238,47 @@ describe PostRank::URI do
     end
 
     context "TLDs" do
-      it "should not pick up bad grammar as a domain name and think it has a link" do
+      it "does not pick up bad grammar as a domain name and think it has a link" do
         expect(e("yah.lets")).to be_empty
       end
 
-      it "should not pickup bad TLDS" do
+      it "does not pickup bad TLDS" do
         expect(e('stuff.zz a.b.c d.zq')).to be_empty
       end
     end
 
-    it "should extract twitter links with hashbangs" do
+    it "extracts twitter links with hashbangs" do
       expect(e('test http://twitter.com/#!/igrigorik')).to include('http://twitter.com/igrigorik')
     end
 
-    it "should extract mobile twitter links with hashbangs" do
+    it "extracts mobile twitter links with hashbangs" do
       expect(e('test http://mobile.twitter.com/#!/_mm6')).to include('http://mobile.twitter.com/_mm6')
     end
 
-    it "should handle a URL that comes after text without a space" do
+    it "handles a URL that comes after text without a space" do
       expect(e("text:http://spn.tw/tfnLT")).to include("http://spn.tw/tfnLT")
       expect(e("text;http://spn.tw/tfnLT")).to include("http://spn.tw/tfnLT")
       expect(e("text.http://spn.tw/tfnLT")).to include("http://spn.tw/tfnLT")
       expect(e("text-http://spn.tw/tfnLT")).to include("http://spn.tw/tfnLT")
     end
 
-    it "should not pick up anything on or after the first . in the path of a URL with a shortener domain" do
+    it "does not pick up anything on or after the first . in the path of a URL with a shortener domain" do
       expect(e("http://bit.ly/9cJ2mz......if ur pickin up anythign here, u FAIL.")).to eq(["http://bit.ly/9cJ2mz"])
     end
 
-    it "should pickup urls without protocol" do
+    it "picks up urls without protocol" do
       u = e('abc.com abc.co')
       expect(u).to include('http://abc.com/')
       expect(u).to include('http://abc.co/')
     end
 
-    it "should pickup urls inside tags" do
+    it "picks up urls inside tags" do
       u = e("<a href='http://bit.ly/3fds3'>abc.com</a>")
       expect(u).to include('http://abc.com/')
     end
 
     context "multibyte characters" do
-      it "should stop extracting URLs at the full-width CJK space character" do
+      it "stops extracting URLs at the full-width CJK space character" do
         expect(e("http://www.youtube.com/watch?v=w_j4Lda25jA　　とんかつ定食")).to eq(["http://www.youtube.com/watch?v=w_j4Lda25jA"])
       end
     end
@@ -286,7 +286,7 @@ describe PostRank::URI do
   end
 
   context "href extract" do
-    it "should extract links from html text" do
+    it "extracts links from html text" do
       g,b = PostRank::URI.extract_href("<a href='google.com'>link to google</a> with text <a href='b.com'>stuff</a>")
 
       expect(g.first).to eq('http://google.com/')
@@ -296,7 +296,7 @@ describe PostRank::URI do
       expect(b.last).to eq('stuff')
     end
 
-    it "should handle empty hrefs" do
+    it "handles empty hrefs" do
       expect do
         l = PostRank::URI.extract_href("<a>link to google</a> with text <a href=''>stuff</a>")
         expect(l).to be_empty
@@ -304,12 +304,12 @@ describe PostRank::URI do
     end
 
     context "relative paths" do
-      it "should reject relative paths" do
+      it "rejects relative paths" do
         l = PostRank::URI.extract_href("<a href='/stuff'>link to stuff</a>")
         expect(l).to be_empty
       end
 
-      it "should resolve relative paths if host is provided" do
+      it "resolves relative paths if host is provided" do
         i = PostRank::URI.extract_href("<a href='/stuff'>link to stuff</a>", "igvita.com").first
         expect(i.first).to eq('http://igvita.com/stuff')
         expect(i.last).to eq('link to stuff')
@@ -337,7 +337,7 @@ describe PostRank::URI do
       }
 
       url_list.each_pair do |url, expected_result|
-        it "should extract #{expected_result.inspect} from #{url}" do
+        it "extracts #{expected_result.inspect} from #{url}" do
           u = PostRank::URI.clean(url, :raw => true)
           expect(u.domain).to eq(expected_result)
         end
@@ -346,19 +346,19 @@ describe PostRank::URI do
   end
 
   context "parse" do
-    it 'should not fail on large host-part look-alikes' do
+    it 'does not fail on large host-part look-alikes' do
       expect(PostRank::URI.parse('a'*64+'.ca').host).to eq(nil)
     end
 
-    it 'should not pancake javascript scheme URIs' do
+    it 'does not pancake javascript scheme URIs' do
       expect(PostRank::URI.parse('javascript:void(0);').scheme).to eq('javascript')
     end
 
-    it 'should not pancake mailto scheme URIs' do
+    it 'does not pancake mailto scheme URIs' do
       expect(PostRank::URI.parse('mailto:void(0);').scheme).to eq('mailto')
     end
 
-    it 'should not pancake xmpp scheme URIs' do
+    it 'does not pancake xmpp scheme URIs' do
       expect(PostRank::URI.parse('xmpp:void(0);').scheme).to eq('xmpp')
     end
   end

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -195,12 +195,17 @@ describe PostRank::URI do
     end
 
     context "reserved characters" do
-      it "preserves encoded question marks in the path" do
+      it "preserves encoded question marks" do
         c('http://en.wikipedia.org/wiki/Whose_Line_Is_It_Anyway%3F_%28U.S._TV_series%29').
           should == 'http://en.wikipedia.org/wiki/Whose_Line_Is_It_Anyway%3F_(U.S._TV_series)'
       end
 
-      it "preserves multiple question marks in the path" do
+      it "preserves encoded ampersands" do
+        c('http://example.com/?foo=BAR%26BAZ').
+          should == 'http://example.com/?foo=BAR%26BAZ'
+      end
+
+      it "preserves consecutive reserved characters" do
         c('http://example.com/so-quizical%3F%3F%3F?foo=bar').
           should == 'http://example.com/so-quizical%3F%3F%3F?foo=bar'
       end

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -193,6 +193,18 @@ describe PostRank::URI do
         c(orig).should == clean
       end
     end
+
+    context "reserved characters" do
+      it "preserves encoded question marks in the path" do
+        c('http://en.wikipedia.org/wiki/Whose_Line_Is_It_Anyway%3F_%28U.S._TV_series%29').
+          should == 'http://en.wikipedia.org/wiki/Whose_Line_Is_It_Anyway%3F_(U.S._TV_series)'
+      end
+
+      it "preserves multiple question marks in the path" do
+        c('http://example.com/so-quizical%3F%3F%3F?foo=bar').
+          should == 'http://example.com/so-quizical%3F%3F%3F?foo=bar'
+      end
+    end
   end
 
   context "hash" do

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -53,17 +53,17 @@ describe PostRank::URI do
 
     it "should handle hex and utf-8 encoding in same url" do
       uri = Addressable::URI.parse("%C2%A9_\u{00A1}")
-      PostRank::URI.unescape(uri).should == "©_¡"
+      expect(PostRank::URI.unescape(uri)).to eq ("©_¡")
     end
 
     it "handles reserved chars next to unreserved and encoded chars" do
       uri = Addressable::URI.parse("http://example.com/%7C%25")
-      PostRank::URI.unescape(uri).should == "http://example.com/|%"
+      expect(PostRank::URI.unescape(uri)).to eq ("http://example.com/|%")
     end
 
     it "doesn't break on fancy UTF-8 characters" do
       uri = Addressable::URI.parse("http://example.com/someregulartext%25💀%25🍻%25")
-      PostRank::URI.unescape(uri).should == "http://example.com/someregulartext%💀%🍻%"
+      expect(PostRank::URI.unescape(uri)).to eq ("http://example.com/someregulartext%💀%🍻%")
     end
   end
 
@@ -73,30 +73,30 @@ describe PostRank::URI do
     end
 
     it "should not unescape reserved characters" do
-      uu("example.com/what%3F").should == "http://example.com/what%3F"
+      expect(uu("example.com/what%3F")).to eq ("http://example.com/what%3F")
     end
 
     it "should unescape unreserved characters" do
-      uu("example.com/some%20thing").should == "http://example.com/some thing"
+      expect(uu("example.com/some%20thing")).to eq ("http://example.com/some thing")
     end
 
     it "should not unescape percents" do
-      uu("example.com/work%20110%25").should == "http://example.com/work 110%25"
+      expect(uu("example.com/work%20110%25")).to eq ("http://example.com/work 110%25")
     end
 
     it "should handle hex and utf-8 encoding in same url" do
       uri = Addressable::URI.parse("http://example.com/%C2%A9_\u{00A1}")
-      uu(uri).should == "http://example.com/©_¡"
+      expect(uu(uri)).to eq ("http://example.com/©_¡")
     end
 
     it "handles reserved chars next to unreserved and encoded chars" do
       uri = Addressable::URI.parse("http://example.com/%7C%25")
-      uu(uri).should == "http://example.com/|%25"
+      expect(uu(uri)).to eq ("http://example.com/|%25")
     end
 
     it "doesn't break on fancy UTF-8 characters" do
       uri = Addressable::URI.parse("http://example.com/someregulartext%25💀%25🍻%25")
-      uu(uri).should == "http://example.com/someregulartext%25💀%25🍻%25"
+      expect(uu(uri)).to eq ("http://example.com/someregulartext%25💀%25🍻%25")
     end
   end
 
@@ -154,21 +154,21 @@ describe PostRank::URI do
     end
 
     it "should not remove trailing slash on paths if asked not to" do
-      n('http://igvita.com/', :remove_trailing_slash => false).should == 'http://igvita.com/'
+      expect(n('http://igvita.com/', :remove_trailing_slash => false)).to eq('http://igvita.com/')
 
-      n('http://igvita.com/a', :remove_trailing_slash => false).should == 'http://igvita.com/a'
-      n('http://igvita.com/a/', :remove_trailing_slash => false).should == 'http://igvita.com/a/'
+      expect(n('http://igvita.com/a', :remove_trailing_slash => false)).to eq('http://igvita.com/a')
+      expect(n('http://igvita.com/a/', :remove_trailing_slash => false)).to eq('http://igvita.com/a/')
 
-      n('http://igvita.com/a/b', :remove_trailing_slash => false).should == 'http://igvita.com/a/b'
-      n('http://igvita.com/a/b/', :remove_trailing_slash => false).should == 'http://igvita.com/a/b/'
+      expect(n('http://igvita.com/a/b', :remove_trailing_slash => false)).to eq('http://igvita.com/a/b')
+      expect(n('http://igvita.com/a/b/', :remove_trailing_slash => false)).to eq('http://igvita.com/a/b/')
     end
 
     it "should not mangle this real life url" do
       src_url = 'http://www.tesco.com/direct/gaming/games-bargains/cat13350049.cat?catId=4294890098+51439+40678+40679&lastFilter=Price|%25A310+to+%C2%A320&icid=ents_flyoutlink_BargainsChartsGames'
       expected_url = 'http://www.tesco.com/direct/gaming/games-bargains/cat13350049.cat?catId=4294890098+51439+40678+40679&lastFilter=Price%7C%25A310+to+%C2%A320&icid=ents_flyoutlink_BargainsChartsGames'
 
-      n(src_url).should == expected_url
-      n(n(n(n(src_url)))).should == expected_url
+      expect(n(src_url)).to eq(expected_url)
+      expect(n(n(n(n(src_url))))).to eq(expected_url)
     end
   end
 
@@ -204,8 +204,8 @@ describe PostRank::URI do
       end
 
       it "should remove jsessionid parameter" do
-        c('http://foo.org/bar/;jsessionid=CFF4F98856B808B7D643F56D3EEE95BE.juno_qa_fye').should == 'http://foo.org/bar/'
-        c('http://foo.org/bar/?baz=1;jsessionid=CFF4F98856B808B7D643F56D3EEE95BE.juno_qa_fye').should == 'http://foo.org/bar/?baz=1'
+        expect(c('http://foo.org/bar/;jsessionid=CFF4F98856B808B7D643F56D3EEE95BE.juno_qa_fye')).to eq ('http://foo.org/bar/')
+        expect(c('http://foo.org/bar/?baz=1;jsessionid=CFF4F98856B808B7D643F56D3EEE95BE.juno_qa_fye')).to eq ('http://foo.org/bar/?baz=1')
       end
     end
 
@@ -264,23 +264,23 @@ describe PostRank::URI do
       c('igvita.com?id=<>').should == 'http://igvita.com/?id=%3C%3E'
       c('igvita.com?id="').should == 'http://igvita.com/?id=%22'
 
-      c('test.tumblr.com/post/23223/text-stub').should == 'http://test.tumblr.com/post/23223'
+      expect(c('test.tumblr.com/post/23223/text-stub')).to eq ('http://test.tumblr.com/post/23223')
 
-      c('example.com/do_you_%23yolo%3F').should == 'http://example.com/do_you_%23yolo%3F'
-      c('example.com/search?q=%23fomo&limit=50#entry-1').should == 'http://example.com/search?q=%23fomo&limit=50'
+      expect(c('example.com/do_you_%23yolo%3F')).to eq ('http://example.com/do_you_%23yolo%3F')
+      expect(c('example.com/search?q=%23fomo&limit=50#entry-1')).to eq ('http://example.com/search?q=%23fomo&limit=50')
     end
 
     it "should remove trailing slashes, unless asked not to" do
-      c('http://igvita.com/foo/').should == 'http://igvita.com/foo'
-      c('http://igvita.com/foo/', :remove_trailing_slash => false).should == 'http://igvita.com/foo/'
+      expect(c('http://igvita.com/foo/')).to eq ('http://igvita.com/foo')
+      expect(c('http://igvita.com/foo/', :remove_trailing_slash => false)).to eq ('http://igvita.com/foo/')
     end
 
     it "should not mangle this real life url" do
       src_url = 'http://www.tesco.com/direct/gaming/games-bargains/cat13350049.cat?catId=4294890098+51439+40678+40679&lastFilter=Price|%25A310+to+%C2%A320&icid=ents_flyoutlink_BargainsChartsGames'
       expected_url = 'http://www.tesco.com/direct/gaming/games-bargains/cat13350049.cat?catId=4294890098%2051439%2040678%2040679&lastFilter=Price%7C%25A310%20to%20%C2%A320&icid=ents_flyoutlink_BargainsChartsGames'
 
-      c(src_url).should == expected_url
-      c(c(c(c(src_url)))).should == expected_url
+      expect(c(src_url)).to eq (expected_url)
+      expect(c(c(c(c(src_url))))).to eq (expected_url)
     end
 
     it "should raise an error on invalid characters" do
@@ -451,23 +451,23 @@ describe PostRank::URI do
 
   context 'valid?' do
     it 'marks incomplete URI string as invalid' do
-      PostRank::URI.valid?('/path/page.html').should be(false)
+      expect(PostRank::URI.valid?('/path/page.html')).to be false
     end
 
     it 'marks www.test.c as invalid' do
-      PostRank::URI.valid?('http://www.test.c').should be(false)
+      expect(PostRank::URI.valid?('http://www.test.c')).to be false
     end
 
     it 'marks www.test.com as valid' do
-      PostRank::URI.valid?('http://www.test.com').should be(true)
+      expect(PostRank::URI.valid?('http://www.test.com')).to be true
     end
 
     it 'marks Unicode domain as valid (NOTE: works only with a scheme)' do
-      PostRank::URI.valid?('http://президент.рф').should be(true)
+      expect(PostRank::URI.valid?('http://президент.рф')).to be true
     end
 
     it 'marks punycode domain domain as valid' do
-      PostRank::URI.valid?('xn--d1abbgf6aiiy.xn--p1ai').should be(true)
+      expect(PostRank::URI.valid?('xn--d1abbgf6aiiy.xn--p1ai')).to be true
     end
   end
 end

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -3,103 +3,101 @@
 require 'helper'
 
 describe PostRank::URI do
-
-  let(:igvita) { 'http://igvita.com/' }
-
   context "escaping" do
     it "should escape PostRank::URI string" do
-      PostRank::URI.escape('id=1').should == 'id%3D1'
+      expect(PostRank::URI.escape('id=1')).to eq('id%3D1')
     end
 
     it "should escape spaces as %20's" do
-      PostRank::URI.escape('id= 1').should match('%20')
+      expect(PostRank::URI.escape('id= 1')).to match('%20')
     end
   end
 
   context "unescape" do
     it "should unescape PostRank::URI" do
-      PostRank::URI.unescape(PostRank::URI.escape('id=1')).should == 'id=1'
+      expect(PostRank::URI.unescape(PostRank::URI.escape('id=1'))).to eq('id=1')
     end
 
     it "should unescape PostRank::URI with spaces" do
-      PostRank::URI.unescape(PostRank::URI.escape('id= 1')).should == 'id= 1'
+      expect(PostRank::URI.unescape(PostRank::URI.escape('id= 1'))).to eq('id= 1')
     end
 
     context "accept improperly escaped PostRank::URI strings" do
       # See http://tools.ietf.org/html/rfc3986#section-2.3
 
       it "should unescape PostRank::URI with spaces encoded as '+'" do
-        PostRank::URI.unescape('?id=+1').should == '?id= 1'
+        expect(PostRank::URI.unescape('?id=+1')).to eq('?id= 1')
       end
 
       it "should unescape PostRank::URI with spaces encoded as '+'" do
-        PostRank::URI.unescape('?id%3D+1').should == '?id= 1'
+        expect(PostRank::URI.unescape('?id%3D+1')).to eq('?id= 1')
       end
 
       it "should unescape PostRank::URI with spaces encoded as %20" do
-        PostRank::URI.unescape('?id=%201').should == '?id= 1'
+        expect(PostRank::URI.unescape('?id=%201')).to eq('?id= 1')
       end
 
       it "should not unescape '+' to spaces in paths" do
-        PostRank::URI.unescape('/foo+bar?id=foo+bar').should == '/foo+bar?id=foo bar'
+        expect(PostRank::URI.unescape('/foo+bar?id=foo+bar')).to eq('/foo+bar?id=foo bar')
       end
     end
 
   end
 
   context "normalize" do
+    let(:igvita) { 'http://igvita.com/' }
+
     def n(uri)
       PostRank::URI.normalize(uri).to_s
     end
 
     it "should normalize paths in PostRank::URIs" do
-      n('http://igvita.com/').should == igvita
-      n('http://igvita.com').to_s.should == igvita
-      n('http://igvita.com///').should == igvita
+      expect(n('http://igvita.com/')).to eq(igvita)
+      expect(n('http://igvita.com').to_s).to eq(igvita)
+      expect(n('http://igvita.com///')).to eq(igvita)
 
-      n('http://igvita.com/../').should == igvita
-      n('http://igvita.com/a/b/../../').should == igvita
-      n('http://igvita.com/a/b/../..').should == igvita
+      expect(n('http://igvita.com/../')).to eq(igvita)
+      expect(n('http://igvita.com/a/b/../../')).to eq(igvita)
+      expect(n('http://igvita.com/a/b/../..')).to eq(igvita)
     end
 
     it "should normalize query strings in PostRank::URIs" do
-      n('http://igvita.com/?').should == igvita
-      n('http://igvita.com?').should == igvita
-      n('http://igvita.com/a/../?').should == igvita
+      expect(n('http://igvita.com/?')).to eq(igvita)
+      expect(n('http://igvita.com?')).to eq(igvita)
+      expect(n('http://igvita.com/a/../?')).to eq(igvita)
     end
 
     it "should normalize anchors in PostRank::URIs" do
-      n('http://igvita.com#test').should == igvita
-      n('http://igvita.com#test#test').should == igvita
-      n('http://igvita.com/a/../?#test').should == igvita
+      expect(n('http://igvita.com#test')).to eq(igvita)
+      expect(n('http://igvita.com#test#test')).to eq(igvita)
+      expect(n('http://igvita.com/a/../?#test')).to eq(igvita)
     end
 
     it "should clean whitespace in PostRank::URIs" do
-      n('http://igvita.com/a/../?  ').should == igvita
-      n('http://igvita.com/a/../? #test').should == igvita
-      n('http://igvita.com/ /../').should == igvita
+      expect(n('http://igvita.com/a/../?  ')).to eq(igvita)
+      expect(n('http://igvita.com/a/../? #test')).to eq(igvita)
+      expect(n('http://igvita.com/ /../')).to eq(igvita)
     end
 
     it "should default to http scheme if missing" do
-      n('igvita.com').should == igvita
-      n('https://test.com/').to_s.should == 'https://test.com/'
+      expect(n('igvita.com')).to eq(igvita)
+      expect(n('https://test.com/').to_s).to eq('https://test.com/')
     end
 
     it "should downcase hostname" do
-      n('IGVITA.COM').should == igvita
-      n('IGVITA.COM/ABC').should == (igvita + "ABC")
+      expect(n('IGVITA.COM')).to eq(igvita)
+      expect(n('IGVITA.COM/ABC')).to eq(igvita + "ABC")
     end
 
     it "should remove trailing slash on paths" do
-      n('http://igvita.com/').should == 'http://igvita.com/'
+      expect(n('http://igvita.com/')).to eq('http://igvita.com/')
 
-      n('http://igvita.com/a').should == 'http://igvita.com/a'
-      n('http://igvita.com/a/').should == 'http://igvita.com/a'
+      expect(n('http://igvita.com/a')).to eq('http://igvita.com/a')
+      expect(n('http://igvita.com/a/')).to eq('http://igvita.com/a')
 
-      n('http://igvita.com/a/b').should == 'http://igvita.com/a/b'
-      n('http://igvita.com/a/b/').should == 'http://igvita.com/a/b'
+      expect(n('http://igvita.com/a/b')).to eq('http://igvita.com/a/b')
+      expect(n('http://igvita.com/a/b/')).to eq('http://igvita.com/a/b')
     end
-
   end
 
   context "canonicalization" do
@@ -109,60 +107,60 @@ describe PostRank::URI do
 
     context "query parameters" do
       it "should handle nester parameters" do
-        c('igvita.com/?id=a&utm_source=a').should == 'http://igvita.com/?id=a'
+        expect(c('igvita.com/?id=a&utm_source=a')).to eq('http://igvita.com/?id=a')
       end
 
       it "should preserve order of parameters" do
         url = 'http://a.com/?'+('a'..'z').to_a.shuffle.map {|e| "#{e}=#{e}"}.join("&")
-        c(url).should == url
+        expect(c(url)).to eq(url)
       end
 
       it "should remove Google Analytics parameters" do
-        c('igvita.com/?id=a&utm_source=a').should == 'http://igvita.com/?id=a'
-        c('igvita.com/?id=a&utm_source=a&utm_valid').should == 'http://igvita.com/?id=a&utm_valid'
+        expect(c('igvita.com/?id=a&utm_source=a')).to eq('http://igvita.com/?id=a')
+        expect(c('igvita.com/?id=a&utm_source=a&utm_valid')).to eq('http://igvita.com/?id=a&utm_valid')
       end
 
       it "should remove awesm/sms parameters" do
-        c('igvita.com/?id=a&utm_source=a&awesm=b').should == 'http://igvita.com/?id=a'
-        c('igvita.com/?id=a&sms_ss=a').should == 'http://igvita.com/?id=a'
+        expect(c('igvita.com/?id=a&utm_source=a&awesm=b')).to eq('http://igvita.com/?id=a')
+        expect(c('igvita.com/?id=a&sms_ss=a')).to eq('http://igvita.com/?id=a')
       end
 
       it "should remove PHPSESSID parameter" do
-        c('http://www.nachi.org/forum?PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd').should == 'http://www.nachi.org/forum?'
-        c('http://www.nachi.org/forum/?PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd').should == 'http://www.nachi.org/forum/?'
-        c('http://www.nachi.org/forum?id=123&PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd').should == 'http://www.nachi.org/forum?id=123'
+        expect(c('http://www.nachi.org/forum?PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd')).to eq('http://www.nachi.org/forum?')
+        expect(c('http://www.nachi.org/forum/?PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd')).to eq('http://www.nachi.org/forum/?')
+        expect(c('http://www.nachi.org/forum?id=123&PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd')).to eq('http://www.nachi.org/forum?id=123')
       end
     end
 
     context "hashbang" do
       it "should rewrite twitter links to crawlable versions" do
-        c('http://twitter.com/#!/igrigorik').should == 'http://twitter.com/igrigorik'
-        c('http://twitter.com/#!/a/statuses/1').should == 'http://twitter.com/a/statuses/1'
-        c('http://nontwitter.com/#!/a/statuses/1').should == 'http://nontwitter.com/#!/a/statuses/1'
+        expect(c('http://twitter.com/#!/igrigorik')).to eq('http://twitter.com/igrigorik')
+        expect(c('http://twitter.com/#!/a/statuses/1')).to eq('http://twitter.com/a/statuses/1')
+        expect(c('http://nontwitter.com/#!/a/statuses/1')).to eq('http://nontwitter.com/#!/a/statuses/1')
       end
     end
 
     context "tumblr" do
       it "should strip slug" do
-        c('http://test.tumblr.com/post/4533459403/some-text').should == 'http://test.tumblr.com/post/4533459403/'
-        c('http://tumblr.com/xjl2evo3hh').should == 'http://tumblr.com/xjl2evo3hh'
+        expect(c('http://test.tumblr.com/post/4533459403/some-text')).to eq('http://test.tumblr.com/post/4533459403/')
+        expect(c('http://tumblr.com/xjl2evo3hh')).to eq('http://tumblr.com/xjl2evo3hh')
       end
     end
 
     context "embedded links" do
       it "should extract embedded redirects from Google News" do
         u = c('http://news.google.com/news/url?sa=t&fd=R&&url=http://www.ctv.ca/CTVNews/Politics/20110111/')
-        u.should == 'http://www.ctv.ca/CTVNews/Politics/20110111'
+        expect(u).to eq('http://www.ctv.ca/CTVNews/Politics/20110111')
       end
 
       it "should extract embedded redirects from xfruits.com" do
         u = c('http://xfruits.com/MrGroar/?url=http%3A%2F%2Faap.lesroyaumes.com%2Fdepeches%2Fdepeche351820908.html')
-        u.should == 'http://aap.lesroyaumes.com/depeches/depeche351820908.html'
+        expect(u).to eq('http://aap.lesroyaumes.com/depeches/depeche351820908.html')
       end
 
       it "should extract embedded redirects from MySpace" do
         u = c('http://www.myspace.com/Modules/PostTo/Pages/?u=http%3A%2F%2Fghanaian-chronicle.com%2Fnews%2Fother-news%2Fcanadian-high-commissioner-urges-media%2F&t=Canadian%20High%20Commissioner%20urges%20media')
-        u.should == 'http://ghanaian-chronicle.com/news/other-news/canadian-high-commissioner-urges-media'
+        expect(u).to eq('http://ghanaian-chronicle.com/news/other-news/canadian-high-commissioner-urges-media')
       end
     end
   end
@@ -173,41 +171,41 @@ describe PostRank::URI do
     end
 
     it "should unescape, c14n and normalize" do
-      c('http://igvita.com/?id=1').should == 'http://igvita.com/?id=1'
-      c('igvita.com/?id=1').should == 'http://igvita.com/?id=1'
+      expect(c('http://igvita.com/?id=1')).to eq('http://igvita.com/?id=1')
+      expect(c('igvita.com/?id=1')).to eq('http://igvita.com/?id=1')
 
-      c('http://igvita.com/?id= 1').should == 'http://igvita.com/?id=%201'
-      c('http://igvita.com/?id=+1').should == 'http://igvita.com/?id=%201'
-      c('http://igvita.com/?id%3D%201').should == 'http://igvita.com/?id=%201'
+      expect(c('http://igvita.com/?id= 1')).to eq('http://igvita.com/?id=%201')
+      expect(c('http://igvita.com/?id=+1')).to eq('http://igvita.com/?id=%201')
+      expect(c('http://igvita.com/?id%3D%201')).to eq('http://igvita.com/?id=%201')
 
-      c('igvita.com/a/..?id=1&utm_source=a&awesm=b#c').should == 'http://igvita.com/?id=1'
+      expect(c('igvita.com/a/..?id=1&utm_source=a&awesm=b#c')).to eq('http://igvita.com/?id=1')
 
-      c('igvita.com?id=<>').should == 'http://igvita.com/?id=%3C%3E'
-      c('igvita.com?id="').should == 'http://igvita.com/?id=%22'
+      expect(c('igvita.com?id=<>')).to eq('http://igvita.com/?id=%3C%3E')
+      expect(c('igvita.com?id="')).to eq('http://igvita.com/?id=%22')
 
-      c('test.tumblr.com/post/23223/text-stub').should == 'http://test.tumblr.com/post/23223'
+      expect(c('test.tumblr.com/post/23223/text-stub')).to eq('http://test.tumblr.com/post/23223')
     end
 
     it "should clean host specific parameters" do
       YAML.load_file('spec/c14n_hosts.yml').each do |orig, clean|
-        c(orig).should == clean
+        expect(c(orig)).to eq(clean)
       end
     end
 
     context "reserved characters" do
       it "preserves encoded question marks" do
-        c('http://en.wikipedia.org/wiki/Whose_Line_Is_It_Anyway%3F_%28U.S._TV_series%29').
-          should == 'http://en.wikipedia.org/wiki/Whose_Line_Is_It_Anyway%3F_(U.S._TV_series)'
+        expect(c('http://en.wikipedia.org/wiki/Whose_Line_Is_It_Anyway%3F_%28U.S._TV_series%29')).
+          to eq('http://en.wikipedia.org/wiki/Whose_Line_Is_It_Anyway%3F_(U.S._TV_series)')
       end
 
       it "preserves encoded ampersands" do
-        c('http://example.com/?foo=BAR%26BAZ').
-          should == 'http://example.com/?foo=BAR%26BAZ'
+        expect(c('http://example.com/?foo=BAR%26BAZ')).
+          to eq('http://example.com/?foo=BAR%26BAZ')
       end
 
       it "preserves consecutive reserved characters" do
-        c('http://example.com/so-quizical%3F%3F%3F?foo=bar').
-          should == 'http://example.com/so-quizical%3F%3F%3F?foo=bar'
+        expect(c('http://example.com/so-quizical%3F%3F%3F?foo=bar')).
+          to eq('http://example.com/so-quizical%3F%3F%3F?foo=bar')
       end
     end
   end
@@ -220,17 +218,17 @@ describe PostRank::URI do
     it "should compute the MD5 hash without cleaning the URI" do
       hash = '55fae8910d312b7878a3201ed653b881'
 
-      h('http://everburning.com/feed/post/1').should == hash
-      h('everburning.com/feed/post/1').should_not == hash
+      expect(h('http://everburning.com/feed/post/1')).to eq(hash)
+      expect(h('everburning.com/feed/post/1')).not_to eq(hash)
     end
 
     it "should normalize the URI if requested and compute MD5 hash" do
       hash = '55fae8910d312b7878a3201ed653b881'
 
-      h('http://EverBurning.Com/feed/post/1', :clean => true).should == hash
-      h('Everburning.com/feed/post/1', :clean => true).should == hash
-      h('everburning.com/feed/post/1', :clean => true).should == hash
-      h('everburning.com/feed/post/1/', :clean => true).should == hash
+      expect(h('http://EverBurning.Com/feed/post/1', :clean => true)).to eq(hash)
+      expect(h('Everburning.com/feed/post/1', :clean => true)).to eq(hash)
+      expect(h('everburning.com/feed/post/1', :clean => true)).to eq(hash)
+      expect(h('everburning.com/feed/post/1/', :clean => true)).to eq(hash)
     end
   end
 
@@ -241,47 +239,47 @@ describe PostRank::URI do
 
     context "TLDs" do
       it "should not pick up bad grammar as a domain name and think it has a link" do
-        e("yah.lets").should be_empty
+        expect(e("yah.lets")).to be_empty
       end
 
       it "should not pickup bad TLDS" do
-        e('stuff.zz a.b.c d.zq').should be_empty
+        expect(e('stuff.zz a.b.c d.zq')).to be_empty
       end
     end
 
     it "should extract twitter links with hashbangs" do
-      e('test http://twitter.com/#!/igrigorik').should include('http://twitter.com/igrigorik')
+      expect(e('test http://twitter.com/#!/igrigorik')).to include('http://twitter.com/igrigorik')
     end
 
     it "should extract mobile twitter links with hashbangs" do
-      e('test http://mobile.twitter.com/#!/_mm6').should include('http://mobile.twitter.com/_mm6')
+      expect(e('test http://mobile.twitter.com/#!/_mm6')).to include('http://mobile.twitter.com/_mm6')
     end
 
     it "should handle a URL that comes after text without a space" do
-      e("text:http://spn.tw/tfnLT").should include("http://spn.tw/tfnLT")
-      e("text;http://spn.tw/tfnLT").should include("http://spn.tw/tfnLT")
-      e("text.http://spn.tw/tfnLT").should include("http://spn.tw/tfnLT")
-      e("text-http://spn.tw/tfnLT").should include("http://spn.tw/tfnLT")
+      expect(e("text:http://spn.tw/tfnLT")).to include("http://spn.tw/tfnLT")
+      expect(e("text;http://spn.tw/tfnLT")).to include("http://spn.tw/tfnLT")
+      expect(e("text.http://spn.tw/tfnLT")).to include("http://spn.tw/tfnLT")
+      expect(e("text-http://spn.tw/tfnLT")).to include("http://spn.tw/tfnLT")
     end
 
     it "should not pick up anything on or after the first . in the path of a URL with a shortener domain" do
-      e("http://bit.ly/9cJ2mz......if ur pickin up anythign here, u FAIL.").should == ["http://bit.ly/9cJ2mz"]
+      expect(e("http://bit.ly/9cJ2mz......if ur pickin up anythign here, u FAIL.")).to eq(["http://bit.ly/9cJ2mz"])
     end
 
     it "should pickup urls without protocol" do
       u = e('abc.com abc.co')
-      u.should include('http://abc.com/')
-      u.should include('http://abc.co/')
+      expect(u).to include('http://abc.com/')
+      expect(u).to include('http://abc.co/')
     end
 
     it "should pickup urls inside tags" do
       u = e("<a href='http://bit.ly/3fds3'>abc.com</a>")
-      u.should include('http://abc.com/')
+      expect(u).to include('http://abc.com/')
     end
 
     context "multibyte characters" do
       it "should stop extracting URLs at the full-width CJK space character" do
-        e("http://www.youtube.com/watch?v=w_j4Lda25jA　　とんかつ定食").should == ["http://www.youtube.com/watch?v=w_j4Lda25jA"]
+        expect(e("http://www.youtube.com/watch?v=w_j4Lda25jA　　とんかつ定食")).to eq(["http://www.youtube.com/watch?v=w_j4Lda25jA"])
       end
     end
 
@@ -291,30 +289,30 @@ describe PostRank::URI do
     it "should extract links from html text" do
       g,b = PostRank::URI.extract_href("<a href='google.com'>link to google</a> with text <a href='b.com'>stuff</a>")
 
-      g.first.should == 'http://google.com/'
-      b.first.should == 'http://b.com/'
+      expect(g.first).to eq('http://google.com/')
+      expect(b.first).to eq('http://b.com/')
 
-      g.last.should == 'link to google'
-      b.last.should == 'stuff'
+      expect(g.last).to eq('link to google')
+      expect(b.last).to eq('stuff')
     end
 
     it "should handle empty hrefs" do
-      lambda do
+      expect do
         l = PostRank::URI.extract_href("<a>link to google</a> with text <a href=''>stuff</a>")
-        l.should be_empty
-      end.should_not raise_error
+        expect(l).to be_empty
+      end.not_to raise_error
     end
 
     context "relative paths" do
       it "should reject relative paths" do
         l = PostRank::URI.extract_href("<a href='/stuff'>link to stuff</a>")
-        l.should be_empty
+        expect(l).to be_empty
       end
 
       it "should resolve relative paths if host is provided" do
         i = PostRank::URI.extract_href("<a href='/stuff'>link to stuff</a>", "igvita.com").first
-        i.first.should == 'http://igvita.com/stuff'
-        i.last.should == 'link to stuff'
+        expect(i.first).to eq('http://igvita.com/stuff')
+        expect(i.last).to eq('link to stuff')
       end
     end
 
@@ -341,7 +339,7 @@ describe PostRank::URI do
       url_list.each_pair do |url, expected_result|
         it "should extract #{expected_result.inspect} from #{url}" do
           u = PostRank::URI.clean(url, :raw => true)
-          u.domain.should == expected_result
+          expect(u.domain).to eq(expected_result)
         end
       end
     end
@@ -349,41 +347,41 @@ describe PostRank::URI do
 
   context "parse" do
     it 'should not fail on large host-part look-alikes' do
-      PostRank::URI.parse('a'*64+'.ca').host.should == nil
+      expect(PostRank::URI.parse('a'*64+'.ca').host).to eq(nil)
     end
 
     it 'should not pancake javascript scheme URIs' do
-      PostRank::URI.parse('javascript:void(0);').scheme.should == 'javascript'
+      expect(PostRank::URI.parse('javascript:void(0);').scheme).to eq('javascript')
     end
 
     it 'should not pancake mailto scheme URIs' do
-      PostRank::URI.parse('mailto:void(0);').scheme.should == 'mailto'
+      expect(PostRank::URI.parse('mailto:void(0);').scheme).to eq('mailto')
     end
 
     it 'should not pancake xmpp scheme URIs' do
-      PostRank::URI.parse('xmpp:void(0);').scheme.should == 'xmpp'
+      expect(PostRank::URI.parse('xmpp:void(0);').scheme).to eq('xmpp')
     end
   end
 
   context 'valid?' do
     it 'marks incomplete URI string as invalid' do
-      PostRank::URI.valid?('/path/page.html').should be false
+      expect(PostRank::URI.valid?('/path/page.html')).to be false
     end
 
     it 'marks www.test.c as invalid' do
-      PostRank::URI.valid?('http://www.test.c').should be false
+      expect(PostRank::URI.valid?('http://www.test.c')).to be false
     end
 
     it 'marks www.test.com as valid' do
-      PostRank::URI.valid?('http://www.test.com').should be true
+      expect(PostRank::URI.valid?('http://www.test.com')).to be true
     end
 
     it 'marks Unicode domain as valid (NOTE: works only with a scheme)' do
-      PostRank::URI.valid?('http://президент.рф').should be true
+      expect(PostRank::URI.valid?('http://президент.рф')).to be true
     end
 
     it 'marks punycode domain domain as valid' do
-      PostRank::URI.valid?('xn--d1abbgf6aiiy.xn--p1ai').should be true
+      expect(PostRank::URI.valid?('xn--d1abbgf6aiiy.xn--p1ai')).to be true
     end
   end
 end

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -350,23 +350,23 @@ describe PostRank::URI do
 
   context 'valid?' do
     it 'marks incomplete URI string as invalid' do
-      PostRank::URI.valid?('/path/page.html').should be_false
+      PostRank::URI.valid?('/path/page.html').should be false
     end
 
     it 'marks www.test.c as invalid' do
-      PostRank::URI.valid?('http://www.test.c').should be_false
+      PostRank::URI.valid?('http://www.test.c').should be false
     end
 
     it 'marks www.test.com as valid' do
-      PostRank::URI.valid?('http://www.test.com').should be_true
+      PostRank::URI.valid?('http://www.test.com').should be true
     end
 
     it 'marks Unicode domain as valid (NOTE: works only with a scheme)' do
-      PostRank::URI.valid?('http://президент.рф').should be_true
+      PostRank::URI.valid?('http://президент.рф').should be true
     end
 
     it 'marks punycode domain domain as valid' do
-      PostRank::URI.valid?('xn--d1abbgf6aiiy.xn--p1ai').should be_true
+      PostRank::URI.valid?('xn--d1abbgf6aiiy.xn--p1ai').should be true
     end
   end
 end


### PR DESCRIPTION
Mostly just rspec 3 and gemspec changes.

We want to be able to use newer public suffix and this pulls in the upstream changes for that.  Leaves our custom unescape methods in place, as the ones upstream still fail a few of our specs.

TECHOPS-1177