### PR TITLE
Allow any new 1.x nokogiri versions

### DIFF
--- a/SWIFTYPE-CHANGELOG.md
+++ b/SWIFTYPE-CHANGELOG.md
@@ -1,5 +1,10 @@
 # Swiftype Fork of Postrank::URI Changelog
 
+### 1.0.22.swiftype02 / 2018-12-18
+
+* Allow any new 1.x nokogiri versions
+
+
 ### 1.0.22.swiftype01 / 2017-10-12
 
 * First version released as a real rubygem.

--- a/lib/postrank-uri/version.rb
+++ b/lib/postrank-uri/version.rb
@@ -1,5 +1,5 @@
 module PostRank
   module URI
-    VERSION = "1.0.22.swiftype01"
+    VERSION = "1.0.22.swiftype02"
   end
 end

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "addressable",   ">= 2.3.0", "< 2.6"
   s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
-  s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.9"
+  s.add_dependency "nokogiri",      ">= 1.6.1", "< 2"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
This allows us to upgrade to minor releases
without re-releasing this gem every time.