### PR TITLE
Remove + symbol handling from unescape_unreserved method

### DIFF
--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -152,7 +152,7 @@ module PostRank
     # interpreted as UTF-8.
     def unescape_unreserved(uri)
       u = parse(uri)
-      u.query = u.query.tr('+', ' ') if u.query
+
       str = u.to_s.force_encoding("ASCII-8BIT").gsub(URIREGEX[:unescape]) do |code|
         next code if ENCODED_RESERVED_CHARS.include?(code.upcase)
 

--- a/lib/postrank-uri/version.rb
+++ b/lib/postrank-uri/version.rb
@@ -1,5 +1,5 @@
 module PostRank
   module URI
-    VERSION = "1.0.22.swiftype02"
+    VERSION = "1.0.22.swiftype03"
   end
 end

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -71,6 +71,7 @@ describe PostRank::URI do
 
     it "should not unescape reserved characters" do
       expect(uu("example.com/what%3F")).to eq ("http://example.com/what%3F")
+      expect(uu("example.com/what?query=some+thing")).to eq("http://example.com/what?query=some+thing")
     end
 
     it "should unescape unreserved characters" do


### PR DESCRIPTION
## https://github.com/elastic/search-developer-productivity/issues/2494

### Description
Since the `+` symbol is a [reserved symbol](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) (and not `unreserved` as it's written in the method name), and there is an ambiguity in whether it should be escaped or not, but escaping affects our customers, it's required to not unescape it in `unescape_unreserved` method.

This PR is dedicated to stop unescaping the `+` symbol in the URLs