### PR TITLE
[CVE-2026-35611] bumped addressable to 2.9.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -21,3 +21,7 @@ end
 appraise "addressable-2.8" do
   gem "addressable", "~> 2.8.8"
 end
+
+appraise "addressable-2.9" do
+  gem "addressable", "~> 2.9.0"
+end

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ Detecting "duplicate URLs" is a hard problem to solve (expensive in all senses),
 
 ### Setup
 
+For ruby version 2.5.5:
+
 ```
+CPPFLAGS=-DUSE_FFI_CLOSURE_ALLOC rbenv install
+gem install bundler -v 2.3.27
 bundle install
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,20 @@ require 'appraisal'
 module Bundler
   class GemHelper
     def rubygem_push(path)
-      sh("gem push --verbose --host https://artifactory.elstc.co/artifactory/api/gems/swiftype-gems --key elastic '#{path}'")
+      if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new("2.3.0")
+        sh [
+          "gem",
+          "push",
+          "--verbose",
+          "--host",
+          "https://artifactory.elstc.co/artifactory/api/gems/swiftype-gems",
+          "--key",
+          "elastic",
+          path.to_s
+        ]
+      else
+        sh("gem push --verbose --host https://artifactory.elstc.co/artifactory/api/gems/swiftype-gems --key elastic '#{path}'")
+      end
       Bundler.ui.confirm "Pushed #{name} #{version} to artifactory"
     end
   end

--- a/SWIFTYPE-CHANGELOG.md
+++ b/SWIFTYPE-CHANGELOG.md
@@ -1,5 +1,10 @@
 # Swiftype Fork of Postrank::URI Changelog
 
+### 1.0.22.swiftype05 / 2026-04-16
+
+* Add support for addressable 2.9.0
+
+
 ### 1.0.22.swiftype04 / 2026-01-22
 
 * Add support for addressable 2.8.8

--- a/lib/postrank-uri/version.rb
+++ b/lib/postrank-uri/version.rb
@@ -1,5 +1,5 @@
 module PostRank
   module URI
-    VERSION = "1.0.22.swiftype04"
+    VERSION = "1.0.22.swiftype05"
   end
 end

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "postrank-uri"
 
-  s.add_dependency "addressable",   ">= 2.3.0", "< 2.9"
+  s.add_dependency "addressable",   ">= 2.3.0", "< 3.0"
   s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
   s.add_dependency "nokogiri",      ">= 1.6.1", "< 2"
 


### PR DESCRIPTION
[CVE-2026-35611] bumped addressable to 2.9.0